### PR TITLE
updated antora playbook to get work group meetings docs 

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -14,6 +14,9 @@ content:
   - url: https://github.com/OP-TED/epo-docs.git
     start_path: /
     branches: main
+  - url: https://github.com/OP-TED/epo-docs.git
+    start_path: /
+    branches: wg-meetings
   - url: https://github.com/OP-TED/espd-docs.git
     start_path: /
     branches: v1.0.x, v2.0.x, v2.1.x, v3.0.x, v3.0.x-TEDSPD-138

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -25,6 +25,7 @@ TED API is a collection of public interfaces allowing 3rd party applications to 
 The eProcurement Ontology provides the formal, semantic foundation for the creation and reuse of linked open data in the domain of public procurement in the EU.
 
 <<EPO:ROOT:index.adoc#, Read the docs>>
+<<WGM:ROOT:index.adoc#, Work group meetings>>
 ****
 [.tile]
 .ESPD EDM

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -25,7 +25,6 @@ TED API is a collection of public interfaces allowing 3rd party applications to 
 The eProcurement Ontology provides the formal, semantic foundation for the creation and reuse of linked open data in the domain of public procurement in the EU.
 
 <<EPO:ROOT:index.adoc#, Read the docs>>
-<<WGM:ROOT:index.adoc#, Work group meetings>>
 ****
 [.tile]
 .ESPD EDM


### PR DESCRIPTION
Meetings docs are now on wg-meetings branch on epo-docs repo 