### PR TITLE
added manual trigger for antora build docs process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: TED Developer Docs
 
 on:
+  workflow_dispatch:
   push:
     branches: 
       - master


### PR DESCRIPTION
This should be in place in case some of the repositories needed to build the documentation will change.