### PR TITLE
antora settings to include more heading levels in the TOC

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -16,6 +16,7 @@ antora:
 
 asciidoc:
   attributes:
+    page-toclevels: 6@
     ### Component's Latest Version
     #
     # We want to know the latest version of each component so we can create a redirect for the latest version.


### PR DESCRIPTION
Table of contents should include more heading levels that H1 and H2. This setting will allow H1 to H6.