### PR TITLE
workflows: Use latest version of github-pages-deploy action

### DIFF
--- a/.github/workflows/publish_site.yml
+++ b/.github/workflows/publish_site.yml
@@ -35,10 +35,9 @@ jobs:
         run: yarn run build
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          # ACCESS_TOKEN: # optional
-          TOKEN: "${{ github.token}}"
-          FOLDER: build/site
-          BRANCH: 'gh-pages'
-          COMMIT-MESSAGE: "[CI] Publish Documentation for ${{ github.sha }}"
+          token: "${{ github.token}}"
+          folder: build/site
+          branch: 'gh-pages'
+          commit-message: "[CI] Publish Documentation for ${{ github.sha }}"


### PR DESCRIPTION
Allow the use of the latest v4.x of the action, instead of specifying the version entirely.
This removes a warning for this workflow.

Workflow executed successfully with this change: https://github.com/OP-TED/OP-TED.github.io/actions/runs/5486230213