### PR TITLE
Update nav.adoc

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -8,8 +8,6 @@
 
 * [.separated]#**eProcurement Ontology**#
 * xref:EPO::index.adoc[ePO Docs `{epo_latest_version}`]
-* xref:EPO::index.adoc[ePO Development Docs]
-* xref:EPO::epo-guidelines.adoc[Guidelines]
 * xref:epo-wgm::index.adoc[Working Group Meetings]
 * xref:rdf-mapping::index.adoc[XML to RDF Mappings]
 * xref:rdf-conversion::index.adoc[XML to RDF Conversion]


### PR DESCRIPTION
Removed the duplicate nav link to the ePO home page as well as the link to the epo-guidelines page that doesn't exist anymore.