### PR TITLE
Index resize tests

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -46,7 +46,7 @@ content:
   ### eForms SDK
   - url: https://github.com/OP-TED/eforms-docs.git
     start_path: /
-    branches: 1.10.x, 1.9.x, 1.9.x-generated, 1.8.x, 1.8.x-generated, 1.7.x, 1.7.x-generated, 1.6.x, 1.6.x-generated, 1.5.x, 1.5.x-generated #, 1.4.x, 1.4.x-generated, main # The "main" branch contains the eForms FAQ and RoadMap
+    branches: 1.10.x, 1.9.x, 1.9.x-generated, 1.8.x, 1.8.x-generated, 1.7.x, 1.7.x-generated, 1.6.x, 1.6.x-generated, 1.5.x, 1.5.x-generated , 1.4.x, 1.4.x-generated, main # The "main" branch contains the eForms FAQ and RoadMap
 
   ### ePO Documentation
   - url: https://github.com/OP-TED/epo-docs.git

--- a/config/docsearch-config.json
+++ b/config/docsearch-config.json
@@ -17,11 +17,7 @@
     ".*/eforms/.*/reference/code-lists/index.html",
     ".*/eforms/.*/reference/business-rules/",
     ".*/eforms/.*/schema/all-in-one.html",
-    ".*/_attachments",
-    ".*/eforms/1.4",
-    ".*/eforms/1.3",
-    ".*/eforms/1.5",
-    ".*/eforms/1.6"
+    ".*/_attachments"
   ],
   "selectors": {
     "default": {

--- a/config/docsearch-config.json
+++ b/config/docsearch-config.json
@@ -16,7 +16,12 @@
     ".*/eforms/.*/reference/business-terms/index.html",
     ".*/eforms/.*/reference/code-lists/index.html",
     ".*/eforms/.*/reference/business-rules/",
-    ".*/eforms/.*/schema/all-in-one.html"
+    ".*/eforms/.*/schema/all-in-one.html",
+    "*/_attachments",
+    ".*/eforms/1.4",
+    ".*/eforms/1.3",
+    ".*/eforms/1.5",
+    ".*/eforms/1.6"
   ],
   "selectors": {
     "default": {

--- a/config/docsearch-config.json
+++ b/config/docsearch-config.json
@@ -17,7 +17,7 @@
     ".*/eforms/.*/reference/code-lists/index.html",
     ".*/eforms/.*/reference/business-rules/",
     ".*/eforms/.*/schema/all-in-one.html",
-    "*/_attachments",
+    "*./_attachments",
     ".*/eforms/1.4",
     ".*/eforms/1.3",
     ".*/eforms/1.5",

--- a/config/docsearch-config.json
+++ b/config/docsearch-config.json
@@ -17,7 +17,7 @@
     ".*/eforms/.*/reference/code-lists/index.html",
     ".*/eforms/.*/reference/business-rules/",
     ".*/eforms/.*/schema/all-in-one.html",
-    "*./_attachments",
+    ".*/_attachments",
     ".*/eforms/1.4",
     ".*/eforms/1.3",
     ".*/eforms/1.5",


### PR DESCRIPTION
I added 1.4.x for the SDK and removed the attachments folder(s), as the next step to reduce records. We are marginally off the limit (by less than 1K records) but it seems to be able to build the index. We can monitor this today and continue removing things tomorrow if necessary.