### PR TITLE
Updated nav, index & playbook to include reuse docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -70,6 +70,10 @@ content:
     start_path: docs/antora 
     branches: main
 
+  ### TED Data for Reusers
+  - url: https://github.com/OP-TED/ted-reuse-docs.git
+    start_path: /
+    branches: main 
 
 urls:
   redirect_facility: static

--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -17,3 +17,6 @@
 * [.separated]#**ESPD-EDM**#
 * xref:ESPD-EDM::index.adoc[ESPD-EDM Docs `{espd_latest_version}`]
 * xref:espd-ouc::index.adoc[Open User Community Meetings]
+
+* [.separated]#**Reusing TED Data**#
+* xref:reuse::index.adoc[Downloading TED Notices]

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -45,4 +45,11 @@ The TED Semantic Web Service allows machine-to-machine interaction with public p
 <<SWS:ROOT:index.adoc#, Read the docs>>
 ****
 
+[.tile]
+.Reusing TED Data 
+****
+Learn how to download TED notices in various formats via the TED Website and API. Daily or monthly packages are available.
+
+<<reuse:ROOT:index.adoc#, Read the docs>>
+****
 --


### PR DESCRIPTION
Include the Reuse Ted Data docs on the public docs site