### PR TITLE
workflows: Update action versions

### DIFF
--- a/.github/workflows/index_site.yml
+++ b/.github/workflows/index_site.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get the content of docsearch-config.json as config
         id: docsearch_config

--- a/.github/workflows/publish_site.yml
+++ b/.github/workflows/publish_site.yml
@@ -15,10 +15,10 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
This gets rid of the warning about Node.js actions being deprecated.