### PR TITLE
antora-playbook: Remove branches for old SDK versions

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,7 +47,7 @@ content:
   ### eForms SDK
   - url: https://github.com/OP-TED/eforms-docs.git
     start_path: /
-    branches: 1.12.x, 1.11.x, 1.11.x-generated, 1.10.x, 1.10.x-generated, 1.9.x, 1.9.x-generated, 1.8.x, 1.8.x-generated, 1.7.x, 1.7.x-generated, 1.6.x, 1.6.x-generated, 1.5.x, 1.5.x-generated , 1.4.x, 1.4.x-generated, main # The "main" branch contains the eForms FAQ and RoadMap
+    branches: 1.12.x, 1.11.x, 1.11.x-generated, 1.10.x, 1.10.x-generated, 1.9.x, 1.9.x-generated, 1.8.x, 1.8.x-generated, 1.7.x, 1.7.x-generated, 1.6.x, 1.6.x-generated, main # The "main" branch contains the eForms FAQ and RoadMap
 
   ### ePO Documentation
   - url: https://github.com/OP-TED/epo-docs.git


### PR DESCRIPTION
SDK 1.4 and 1.5 are not accepted for publication since 31/01/2024, so we don't need to keep the branches for their documentation anymore.