### PR TITLE
antora-playbook: Remove eForms SDK docs for version 1.11 and earlier

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -50,7 +50,7 @@ content:
   ### eForms SDK
   - url: https://github.com/OP-TED/eforms-docs.git
     start_path: /
-    branches: 1.14.x, 1.13.x, 1.13.x-generated, 1.12.x, 1.12.x-generated, 1.11.x, 1.11.x-generated, 1.10.x, 1.10.x-generated, 1.9.x, 1.9.x-generated, 1.8.x, 1.8.x-generated, 1.7.x, 1.7.x-generated, 1.6.x, 1.6.x-generated, main # The "main" branch contains the eForms FAQ and RoadMap
+    branches: 1.14.x, 1.13.x, 1.13.x-generated, 1.12.x, 1.12.x-generated, main # The "main" branch contains the eForms FAQ and RoadMap
 
   ### ePO Documentation
   - url: https://github.com/OP-TED/epo-docs.git


### PR DESCRIPTION
Notices with those versions are not accepted for publication any more, so the docs are not needed.

This PR should only be merged after the OK from Karl, as we want the current version of the site to be archived before we remove those pages.